### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/R/sentometrics.R
+++ b/R/sentometrics.R
@@ -28,9 +28,9 @@
 #' @note Please cite the package in publications. Use \code{citation("sentometrics")}.
 #'
 #' @references Ardia, Bluteau and Boudt (2018). ``Questioning the news about economic growth: Sparse forecasting using
-#' thousands of news-based sentiment values''. \emph{Working paper}, \url{http://dx.doi.org/10.2139/ssrn.2976084}.
+#' thousands of news-based sentiment values''. \emph{Working paper}, \url{https://doi.org/10.2139/ssrn.2976084}.
 #' @references Ardia, Bluteau, Borms and Boudt (2018). ``The R package sentometrics to compute, aggregate and
-#' predict with textual sentiment''. \emph{Working paper}, \url{http://dx.doi.org/10.2139/ssrn.3067734}.
+#' predict with textual sentiment''. \emph{Working paper}, \url{https://doi.org/10.2139/ssrn.3067734}.
 "_PACKAGE"
 
 #' Built-in lexicons

--- a/R/sentomodel.R
+++ b/R/sentomodel.R
@@ -60,9 +60,9 @@
 #' @seealso \code{\link{sento_model}}
 #'
 #' @references Tibshirani and Taylor (2012). ``Degrees of freedom in LASSO problems''.
-#' \emph{Annals of Statistics 40, 1198-12}, \url{http://dx.doi.org/10.1214/12-AOS1003}.
+#' \emph{Annals of Statistics 40, 1198-12}, \url{https://doi.org/10.1214/12-AOS1003}.
 #' @references Zou, Hastie and Tibshirani (2007). ``On the `degrees of freedom' of the LASSO''.
-#' \emph{Annals of Statistics 35, 2173-2192},  \url{http://dx.doi.org/10.1214/009053607000000127}.
+#' \emph{Annals of Statistics 35, 2173-2192},  \url{https://doi.org/10.1214/009053607000000127}.
 #'
 #' @examples
 #' # information criterion based model control functions


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and all DOI reference links.

Cheers!