### PR TITLE
Apply fixes for compatibility with upcoming quanteda release

### DIFF
--- a/R/sentocorpus.R
+++ b/R/sentocorpus.R
@@ -47,14 +47,14 @@
 #' corpusSmall <- quanteda::corpus_sample(corp, size = 500)
 #'
 #' # deleting a feature
-#' quanteda::docvars(corp, field = "wapo") <- NULL
+#' #quanteda::docvars(corp, field = "wapo") <- NULL
 #'
 #' # deleting all features results in the addition of a dummy feature
-#' quanteda::docvars(corp, field = c("economy", "noneconomy", "wsj")) <- NULL
+#' #quanteda::docvars(corp, field = c("economy", "noneconomy", "wsj")) <- NULL
 #'
 #' \dontrun{
 #' # to add or replace features, use the add_features() function...
-#' quanteda::docvars(corp, field = c("wsj", "new")) <- 1}
+#' #quanteda::docvars(corp, field = c("wsj", "new")) <- 1}
 #'
 #' # corpus creation when no features are present
 #' corpusDummy <- sento_corpus(corpusdf = usnews[, 1:3])
@@ -101,7 +101,6 @@ sento_corpus <- function(corpusdf, do.clean = FALSE) {
         warning("No remaining feature columns. A 'dummyFeature' feature valued at 1 throughout is added.")
         if (do.clean) corpusdf <- clean_texts(corpusdf)
         corp <- quanteda::corpus(x = corpusdf, docid_field = "id", text_field = "texts", metacorpus = list(info = info))
-        corp$tokens <- NULL
         class(corp) <- c("sentocorpus", class(corp))
         return(corp)
       }
@@ -122,7 +121,6 @@ sento_corpus <- function(corpusdf, do.clean = FALSE) {
 
   if (do.clean) corpusdf <- clean_texts(corpusdf)
   corp <- quanteda::corpus(x = corpusdf, docid_field = "id", text_field = "texts", metacorpus = list(info = info))
-  corp$tokens <- NULL
   class(corp) <- c("sentocorpus", class(corp))
 
   return(corp)
@@ -170,7 +168,9 @@ clean_texts <- function(corpusdf) {
 to_sentocorpus <- function(corpus, dates, do.clean = FALSE) {
   if (length(dates) != quanteda::ndoc(corpus))
     stop("The number of dates in 'dates' should be equal to the number of documents in 'corpus'.")
-  corpusdf <- data.table::as.data.table(corpus$documents)
+  corpusdf <- data.table::as.data.table(data.frame(texts = quanteda::texts(corpus),
+                                                   quanteda::docvars(corpus),
+                                                   stringsAsFactors = FALSE))
   corpusdf[, id := quanteda::docnames(corpus)]
   corpusdf[, date := dates]
   setcolorder(corpusdf, c("id", "date", "texts", setdiff(names(corpusdf), c("id", "date", "texts"))))
@@ -232,12 +232,12 @@ to_sentocorpus <- function(corpus, dates, do.clean = FALSE) {
 #'                                         war = "war"),
 #'                         do.regex = c(TRUE, TRUE, FALSE))
 #'
-#' sum(corpus3$documents$pres) == sum(corpus4$documents$pres2) # TRUE
+#' sum(quanteda::docvars(corpus3, "pres")) ==
+#'   sum(quanteda::docvars(corpus4, "pres2")) # TRUE
 #'
 #' # adding a complementary feature
-#' nonpres <- data.frame(nonpres = as.numeric(!quanteda::docvars(corpus3)[["pres"]]))
-#' corpus3 <- add_features(corpus3,
-#'                         featuresdf = nonpres)
+#' nonpres <- data.frame(nonpres = as.numeric(!quanteda::docvars(corpus3, "pres")))
+#' corpus3 <- add_features(corpus3, featuresdf = nonpres)
 #'
 #' @export
 add_features <- function(corpus, featuresdf = NULL, keywords = NULL, do.binary = TRUE, do.regex = FALSE) {

--- a/R/sentocorpus.R
+++ b/R/sentocorpus.R
@@ -47,14 +47,14 @@
 #' corpusSmall <- quanteda::corpus_sample(corp, size = 500)
 #'
 #' # deleting a feature
-#' #quanteda::docvars(corp, field = "wapo") <- NULL
+#' quanteda::docvars(corp, field = "wapo") <- NULL
 #'
 #' # deleting all features results in the addition of a dummy feature
-#' #quanteda::docvars(corp, field = c("economy", "noneconomy", "wsj")) <- NULL
+#' quanteda::docvars(corp, field = c("economy", "noneconomy", "wsj")) <- NULL
 #'
 #' \dontrun{
 #' # to add or replace features, use the add_features() function...
-#' #quanteda::docvars(corp, field = c("wsj", "new")) <- 1}
+#' quanteda::docvars(corp, field = c("wsj", "new")) <- 1}
 #'
 #' # corpus creation when no features are present
 #' corpusDummy <- sento_corpus(corpusdf = usnews[, 1:3])

--- a/R/sentomeasures_methods.R
+++ b/R/sentomeasures_methods.R
@@ -36,6 +36,7 @@
 #'
 #' \dontrun{
 #' # adjust appearance of plot
+#' library("ggplot2")
 #' p <- plot(sentomeasures)
 #' p <- p +
 #'   scale_x_date(name = "month-year") +

--- a/R/sentomodel.R
+++ b/R/sentomodel.R
@@ -828,7 +828,7 @@ predict.sentomodel <- function(object, newx, type = "response", offset = NULL, .
 #'
 #' # prepare y and other x variables
 #' y <- epu[epu$date %in% get_dates(sentMeas), "index"]
-#' length(y) == nobs(sentMeas1) # TRUE
+#' length(y) == nobs(sentMeas) # TRUE
 #' x <- data.frame(runif(length(y)), rnorm(length(y))) # two other (random) x variables
 #' colnames(x) <- c("x1", "x2")
 #'

--- a/man/add_features.Rd
+++ b/man/add_features.Rd
@@ -66,12 +66,12 @@ corpus4 <- add_features(corpus,
                                         war = "war"),
                         do.regex = c(TRUE, TRUE, FALSE))
 
-sum(corpus3$documents$pres) == sum(corpus4$documents$pres2) # TRUE
+sum(quanteda::docvars(corpus3, "pres")) ==
+  sum(quanteda::docvars(corpus4, "pres2")) # TRUE
 
 # adding a complementary feature
-nonpres <- data.frame(nonpres = as.numeric(!quanteda::docvars(corpus3)[["pres"]]))
-corpus3 <- add_features(corpus3,
-                        featuresdf = nonpres)
+nonpres <- data.frame(nonpres = as.numeric(!quanteda::docvars(corpus3, "pres")))
+corpus3 <- add_features(corpus3, featuresdf = nonpres)
 
 }
 \author{

--- a/man/get_loss_data.Rd
+++ b/man/get_loss_data.Rd
@@ -45,7 +45,7 @@ sentMeas <- sento_measures(corpus, l, ctrA)
 
 # prepare y and other x variables
 y <- epu[epu$date \%in\% get_dates(sentMeas), "index"]
-length(y) == nobs(sentMeas1) # TRUE
+length(y) == nobs(sentMeas) # TRUE
 x <- data.frame(runif(length(y)), rnorm(length(y))) # two other (random) x variables
 colnames(x) <- c("x1", "x2")
 

--- a/man/plot.sentomeasures.Rd
+++ b/man/plot.sentomeasures.Rd
@@ -42,6 +42,7 @@ plot(sentomeasures, group = "features")
 
 \dontrun{
 # adjust appearance of plot
+library("ggplot2")
 p <- plot(sentomeasures)
 p <- p +
   scale_x_date(name = "month-year") +

--- a/man/sento_corpus.Rd
+++ b/man/sento_corpus.Rd
@@ -53,14 +53,14 @@ corp <- sento_corpus(corpusdf = usnews)
 corpusSmall <- quanteda::corpus_sample(corp, size = 500)
 
 # deleting a feature
-#quanteda::docvars(corp, field = "wapo") <- NULL
+quanteda::docvars(corp, field = "wapo") <- NULL
 
 # deleting all features results in the addition of a dummy feature
-#quanteda::docvars(corp, field = c("economy", "noneconomy", "wsj")) <- NULL
+quanteda::docvars(corp, field = c("economy", "noneconomy", "wsj")) <- NULL
 
 \dontrun{
 # to add or replace features, use the add_features() function...
-#quanteda::docvars(corp, field = c("wsj", "new")) <- 1}
+quanteda::docvars(corp, field = c("wsj", "new")) <- 1}
 
 # corpus creation when no features are present
 corpusDummy <- sento_corpus(corpusdf = usnews[, 1:3])

--- a/man/sento_corpus.Rd
+++ b/man/sento_corpus.Rd
@@ -53,14 +53,14 @@ corp <- sento_corpus(corpusdf = usnews)
 corpusSmall <- quanteda::corpus_sample(corp, size = 500)
 
 # deleting a feature
-quanteda::docvars(corp, field = "wapo") <- NULL
+#quanteda::docvars(corp, field = "wapo") <- NULL
 
 # deleting all features results in the addition of a dummy feature
-quanteda::docvars(corp, field = c("economy", "noneconomy", "wsj")) <- NULL
+#quanteda::docvars(corp, field = c("economy", "noneconomy", "wsj")) <- NULL
 
 \dontrun{
 # to add or replace features, use the add_features() function...
-quanteda::docvars(corp, field = c("wsj", "new")) <- 1}
+#quanteda::docvars(corp, field = c("wsj", "new")) <- 1}
 
 # corpus creation when no features are present
 corpusDummy <- sento_corpus(corpusdf = usnews[, 1:3])

--- a/tests/testthat/test_corpus_building.R
+++ b/tests/testthat/test_corpus_building.R
@@ -12,7 +12,8 @@ data("usnews")
 # sento_corpus
 corpus <- sento_corpus(corpusdf = usnews, do.clean = TRUE)
 test_that("Corpus building works and fails when appropriate", {
-  expect_equal(c("texts", "date", "wsj", "wapo", "economy", "noneconomy"), colnames(corpus$documents))
+  expect_equal(c("date", "wsj", "wapo", "economy", "noneconomy"),
+               names(docvars(corpus)))
   expect_warning(corpusDummy <- sento_corpus(corpusdf = usnews[, 1:3]))
   expect_equal(colnames(quanteda::docvars(corpusDummy)), c("date", "dummyFeature"))
   expect_warning(sento_corpus(corpusdf = cbind(usnews, "notNumeric")))
@@ -24,8 +25,8 @@ test_that("Corpus building works and fails when appropriate", {
 # to_sentocorpus
 test_that("Conversion to sentocorpus from quanteda corpus", {
   expect_equal(
-    c("texts", "date", "wsj", "wapo", "economy", "noneconomy"),
-    colnames(to_sentocorpus(quanteda::corpus(usnews, text_field = "texts", docid_field = "id"), dates = usnews$date)$documents)
+    c("date", "wsj", "wapo", "economy", "noneconomy"),
+    names(docvars(to_sentocorpus(quanteda::corpus(usnews, text_field = "texts", docid_field = "id"), dates = usnews$date)))
   )
   expect_warning(to_sentocorpus(
     quanteda::corpus(cbind(usnews, wrong = "nutNumeric"),  text_field = "texts", docid_field = "id"), dates = usnews$date))


### PR DESCRIPTION
We are making changes in a development branch (soon to be 1.5 or maybe 2.0) to the structure of corpus objects and to how docvars are handled. I made a few changes to improve compatibility with these changes, and made sure that they also work with the current (1.4.x).

They almost all concern following this advice: http://quanteda.io/reference/corpus.html#a-warning-on-accessing-corpus-elements

which states:
> A corpus currently consists of an S3 specially classed list of elements, but **you should not access these elements directly**. Use the extractor and replacement functions instead, or else your code is not only going to be uglier, but also likely to break should the internal structure of a corpus object change

The PR uses the accessor and replacement functions to encapsulate access, in a way that ensures that our changes to the corpus structure will not break **sentometrics**.

Thanks!