### PR TITLE
Fix corpus sample

### DIFF
--- a/R/sentomeasures_main.R
+++ b/R/sentomeasures_main.R
@@ -286,7 +286,8 @@ sento_measures <- function(sento_corpus, lexicons, ctr) {
 #'                      list_valence_shifters[["en"]][, c("x", "t")])
 #' sent1 <- compute_sentiment(corpusSample, l1, how = "counts")
 #' sent2 <- compute_sentiment(corpusSample, l2, do.sentence = TRUE)
-#' sent3 <- compute_sentiment(texts(corpusSample), l2, do.sentence = TRUE)
+#' sent3 <- compute_sentiment(quanteda::texts(corpusSample), l2,
+#'                            do.sentence = TRUE)
 #' ctr <- ctr_agg(howTime = c("linear"), by = "year", lag = 3)
 #'
 #' # aggregate into sentiment measures

--- a/man/aggregate.sentiment.Rd
+++ b/man/aggregate.sentiment.Rd
@@ -43,7 +43,8 @@ l2 <- sento_lexicons(list_lexicons[c("LM_en", "HENRY_en")],
                      list_valence_shifters[["en"]][, c("x", "t")])
 sent1 <- compute_sentiment(corpusSample, l1, how = "counts")
 sent2 <- compute_sentiment(corpusSample, l2, do.sentence = TRUE)
-sent3 <- compute_sentiment(texts(corpusSample), l2, do.sentence = TRUE)
+sent3 <- compute_sentiment(quanteda::texts(corpusSample), l2,
+                           do.sentence = TRUE)
 ctr <- ctr_agg(howTime = c("linear"), by = "year", lag = 3)
 
 # aggregate into sentiment measures

--- a/tests/testthat/test_corpus_building.R
+++ b/tests/testthat/test_corpus_building.R
@@ -19,7 +19,7 @@ corpus <- sento_corpus(corpusdf = usnews, do.clean = TRUE)
 test_that("Corpus building works and fails when appropriate", {
   expect_equal(c("date", "wsj", "wapo", "economy", "noneconomy"),
                names(docvars(corpus)))
-  expect_warning(corpusDummy <- sento_corpus(corpusdf = usnews[, 1:3]))
+  expect_message(corpusDummy <- sento_corpus(corpusdf = usnews[, 1:3]))
   expect_equal(colnames(quanteda::docvars(corpusDummy)), c("date", "dummyFeature"))
   expect_warning(sento_corpus(corpusdf = cbind(usnews, "notNumeric")))
   expect_warning(sento_corpus(corpusdf = cbind(usnews[, 1:3], usnews[, -c(1:3)] * 100)))


### PR DESCRIPTION
This fixes the problems with the **quanteda** v2 corpus objects, using https://github.com/quanteda/quanteda/pull/1814 (soon to be merged!). 
It also fixes one other problem I found.

It still fails on https://github.com/sborms/sentometrics/blob/master/tests/testthat/test_sentiment_computation.R#L87-L88 but I will let you fix those (not **quanteda**-related).