### PR TITLE
suggestion

### DIFF
--- a/R/sentiment_engines.R
+++ b/R/sentiment_engines.R
@@ -33,7 +33,7 @@ compute_sentiment_lexicons <- function(x, tokens, dv, lexicons, how, do.sentence
   threads <- min(RcppParallel::defaultNumThreads(), nCore)
   RcppParallel::setThreadOptions(numThreads = threads)
   if (is_only_character(x)) x <- quanteda::corpus(x)
-  if (do.sentence == TRUE | is.null(tokens) ) {
+  if (do.sentence == TRUE | !is.null(tokens) ) {
     tokens <- tokenize_texts(quanteda::texts(x), tokens, type = "sentence")
     valenceType <- ifelse(is.null(lexicons[["valence"]]), 0,
                           ifelse(colnames(lexicons[["valence"]])[2] == "y", 1, 2))

--- a/R/sentiment_engines.R
+++ b/R/sentiment_engines.R
@@ -33,7 +33,7 @@ compute_sentiment_lexicons <- function(x, tokens, dv, lexicons, how, do.sentence
   threads <- min(RcppParallel::defaultNumThreads(), nCore)
   RcppParallel::setThreadOptions(numThreads = threads)
   if (is_only_character(x)) x <- quanteda::corpus(x)
-  if (do.sentence == TRUE) {
+  if (do.sentence == TRUE | is.null(tokens) ) {
     tokens <- tokenize_texts(quanteda::texts(x), tokens, type = "sentence")
     valenceType <- ifelse(is.null(lexicons[["valence"]]), 0,
                           ifelse(colnames(lexicons[["valence"]])[2] == "y", 1, 2))


### PR DESCRIPTION
It seems that it is necessary to explicitly state "do.sentence" as "TRUE" when computing sentiments using the "tokens" argument.
This behavior felt rather odd to me. I suggest the following modification that would hopefully force the usage of "compute_sentiment_sentences" when the "tokens" argument is used.