### PR TITLE
Change usage to avoid warnings for quanteda v3

### DIFF
--- a/R/sentiment_engines.R
+++ b/R/sentiment_engines.R
@@ -34,7 +34,7 @@ compute_sentiment_lexicons <- function(x, tokens, dv, lexicons, how, do.sentence
   RcppParallel::setThreadOptions(numThreads = threads)
   if (is_only_character(x)) x <- quanteda::corpus(x)
   if (do.sentence == TRUE) {
-    tokens <- tokenize_texts(quanteda::texts(x), tokens, type = "sentence")
+    tokens <- tokenize_texts(as.character(x), tokens, type = "sentence")
     valenceType <- ifelse(is.null(lexicons[["valence"]]), 0,
                           ifelse(colnames(lexicons[["valence"]])[2] == "y", 1, 2))
     s <- compute_sentiment_sentences(unlist(tokens, recursive = FALSE),
@@ -50,7 +50,7 @@ compute_sentiment_lexicons <- function(x, tokens, dv, lexicons, how, do.sentence
       data.table::setcolorder(s, c("id", "sentence_id", "word_count"))
     }
   } else {
-    tokens <- tokenize_texts(quanteda::texts(x), tokens, type = "word")
+    tokens <- tokenize_texts(as.character(x), tokens, type = "word")
     if (is.null(lexicons[["valence"]])) { # call to C++ code
       s <- compute_sentiment_onegrams(tokens, lexicons, how)
     } else {

--- a/R/sentocorpus.R
+++ b/R/sentocorpus.R
@@ -246,7 +246,7 @@ add_features <- function(corpus, featuresdf = NULL, keywords = NULL, do.binary =
       stop("Please provide a list with proper names as part of the 'keywords' argument.")
     if (!is_names_correct(names(keywords)))
       stop("At least one feature's name in 'keywords' contains '-'. Please provide proper names.")
-    textsAll <- quanteda::texts(corpus)
+    textsAll <- as.character(corpus)
     if (do.binary == TRUE) fct <- stringi::stri_detect
     else fct <- stringi::stri_count
     N <- length(keywords)
@@ -343,7 +343,7 @@ corpus_summarize <- function(x, by = "day", features = NULL) {
   # statistics
   dt <- data.table::data.table(
     quanteda::docvars(x),
-    "nTokens" = as.numeric(sapply(tokenize_texts(quanteda::texts(x)), length))
+    "nTokens" = as.numeric(sapply(as.character(x), length))
   )
 
   if (!is.null(features)) {
@@ -416,7 +416,7 @@ as.sento_corpus.corpus <- function(x, dates = NULL, do.clean = FALSE) {
     features$date <- dates # avoids accidental duplication
   }
   dt <- data.table::data.table("id" = quanteda::docnames(x),
-                               "texts" = quanteda::texts(x),
+                               "texts" = as.character(x),
                                features) # includes date column
   data.table::setcolorder(dt, c("id", "date", "texts"))
   sento_corpus(dt, do.clean)
@@ -522,14 +522,14 @@ as.sento_corpus <- function(x, dates = NULL, do.clean = FALSE) {
 
 #' @export
 as.data.table.sento_corpus <- function(x, ...) {
-  dt <- data.table::data.table(id = quanteda::docnames(x), texts = quanteda::texts(x), quanteda::docvars(x))
+  dt <- data.table::data.table(id = quanteda::docnames(x), texts = as.character(x), quanteda::docvars(x))
   data.table::setcolorder(dt, c("id", "date", "texts"))
   dt
 }
 
 #' @export
 as.data.frame.sento_corpus <- function(x, ...) {
-  df <- cbind(quanteda::docvars(x), texts = quanteda::texts(x))
+  df <- cbind(quanteda::docvars(x), texts = as.character(x))
   df[, c("date", "texts", setdiff(colnames(df), c("date", "texts")))]
 }
 

--- a/R/sentocorpus.R
+++ b/R/sentocorpus.R
@@ -343,7 +343,7 @@ corpus_summarize <- function(x, by = "day", features = NULL) {
   # statistics
   dt <- data.table::data.table(
     quanteda::docvars(x),
-    "nTokens" = as.numeric(sapply(as.character(x), length))
+    "nTokens" = as.numeric(sapply(tokenize_texts(as.character(x)), length))
   )
 
   if (!is.null(features)) {

--- a/R/sentomeasures_main.R
+++ b/R/sentomeasures_main.R
@@ -286,7 +286,7 @@ sento_measures <- function(sento_corpus, lexicons, ctr) {
 #'                      list_valence_shifters[["en"]][, c("x", "t")])
 #' sent1 <- compute_sentiment(corpusSample, l1, how = "counts")
 #' sent2 <- compute_sentiment(corpusSample, l2, do.sentence = TRUE)
-#' sent3 <- compute_sentiment(quanteda::texts(corpusSample), l2,
+#' sent3 <- compute_sentiment(as.character(corpusSample), l2,
 #'                            do.sentence = TRUE)
 #' ctr <- ctr_agg(howTime = c("linear"), by = "year", lag = 3)
 #'

--- a/R/sentomeasures_measures_xyz.R
+++ b/R/sentomeasures_measures_xyz.R
@@ -166,7 +166,7 @@ measures_update <- function(sento_measures, sento_corpus, lexicons) {
   ctr <- sento_measures$ctr
   sentiment <- sento_measures$sentiment
   partialCorpus <- quanteda::corpus_subset(sento_corpus, !quanteda::docnames(sento_corpus) %in% sentiment$id)
-  if (length(quanteda::texts(partialCorpus)) > 0) {
+  if (quanteda::ndoc(partialCorpus) > 0) {
     partialSentiment <- compute_sentiment(partialCorpus, lexicons, how = ctr$within$howWithin, nCore = ctr$nCore)
     sentiment <- merge(sentiment, partialSentiment)
   }

--- a/appendix/run_timings.R
+++ b/appendix/run_timings.R
@@ -266,7 +266,7 @@ timingsFull.many <- lapply(nTexts, function(n) {
   cat("Run timings for texts size of", n, "\n")
   corpus <-  quanteda::corpus(do.call(rbind, lapply(1:25, function(j) usnews))[keep[1:n], ],
                               text_field = "texts")
-  texts <- quanteda::texts(corpus)
+  texts <- as.character(corpus)
   out <- microbenchmark(
     sentoUnigramsAllFunc(texts),
     sentoUnigramsAllFeaturesFunc(corpus),

--- a/man/aggregate.sentiment.Rd
+++ b/man/aggregate.sentiment.Rd
@@ -42,7 +42,7 @@ l2 <- sento_lexicons(list_lexicons[c("LM_en", "HENRY_en")],
                      list_valence_shifters[["en"]][, c("x", "t")])
 sent1 <- compute_sentiment(corpusSample, l1, how = "counts")
 sent2 <- compute_sentiment(corpusSample, l2, do.sentence = TRUE)
-sent3 <- compute_sentiment(quanteda::texts(corpusSample), l2,
+sent3 <- compute_sentiment(as.character(corpusSample), l2,
                            do.sentence = TRUE)
 ctr <- ctr_agg(howTime = c("linear"), by = "year", lag = 3)
 

--- a/man/merge.sentiment.Rd
+++ b/man/merge.sentiment.Rd
@@ -51,7 +51,7 @@ m3 <- merge(s3, s6)
 m4 <- merge(s4, s5)
 nrow(m4) == nrow(m2) # TRUE
 
-# different methods and weighting add rows and columns
+# different methods and weighting adds rows and columns
 ## rows are added only when the different weighting
 ## approach for a specific method gives other sentiment values
 m5 <- merge(s4, s7)

--- a/tests/testthat/test_aggregation.R
+++ b/tests/testthat/test_aggregation.R
@@ -57,7 +57,7 @@ test_that("Aggregation control function breaks when wrong inputs supplied", {
 
 # aggregate.sentiment
 s1 <- compute_sentiment(corpus, lex, how = "proportional")
-s2 <- compute_sentiment(quanteda::texts(corpus), lex, how = "counts")
+s2 <- compute_sentiment(as.character(corpus), lex, how = "counts")
 s3 <- compute_sentiment(corpus, lexClust, how = "proportionalSquareRoot", do.sentence = TRUE)
 sentimentAgg <- aggregate(s3, ctr_agg(lag = 7), do.full = FALSE)
 test_that("Test input and output of sentiment aggregation functionality", {

--- a/vignettes/examples/sentiment.Rmd
+++ b/vignettes/examples/sentiment.Rmd
@@ -88,7 +88,7 @@ tks <- as.list(tokens(corpus, what = "fastestword"))
 
 lexicons <- sento_lexicons(list_lexicons[c("GI_en", "LM_en", "HENRY_en")])
 
-compute_sentiment(texts(corpus), lexicons, how = "counts", tokens = tks)
+compute_sentiment(as.character(corpus), lexicons, how = "counts", tokens = tks)
 ```
 
 To provide your own tokenized input on sentence-level, beware that you need to provide a `list` of `list`s, and set `do.sentence = TRUE`. See one of the next examples for more info about sentence-level sentiment calculation.
@@ -97,7 +97,7 @@ To provide your own tokenized input on sentence-level, beware that you need to p
 sentences <- tokens(corpus, what = "sentence")
 tks2 <- lapply(sentences, function(s) as.list(tokens(s, what = "word")))
 
-compute_sentiment(texts(corpus), lexicons[2:3], how = "counts", tokens = tks2, do.sentence = TRUE)
+compute_sentiment(as.character(corpus), lexicons[2:3], how = "counts", tokens = tks2, do.sentence = TRUE)
 ```
 
 ### The three key approaches to the sentiment computation


### PR DESCRIPTION
`texts()` is replaced by `as.character()` in the forthcoming **quanteda** v3 release. This PR updates the usage, to avoid warnings when using v3.