### PR TITLE
Fix failure when inputting a quanteda tokens to compute_sentiment with valence lexicon

### DIFF
--- a/R/sentiment_engines.R
+++ b/R/sentiment_engines.R
@@ -25,7 +25,7 @@ tokenize_texts <- function(x, tokens = NULL, type = "word") { # x embeds a chara
         wo[sapply(wo, length) != 0]
       })
     }
-  } else return(tokens)
+  } else return(as.list(tokens))
   tok
 }
 

--- a/tests/testthat/test_sentiment_computation.R
+++ b/tests/testthat/test_sentiment_computation.R
@@ -207,3 +207,6 @@ test_that("Same tf-idf scoring for sentometrics and quanteda", {
                unname(posScores - negScores))
 })
 
+test_that("Acceptance of quanteda tokens for tokens argument", {
+  expect_s3_class(compute_sentiment(corpus, lex, tokens = quanteda::tokens(usnews[1:250, "texts"])), "sentiment")
+})


### PR DESCRIPTION
Just needed to add as.list() to tokenize_texts(). If not, the quanteda tokens is converted to a list of integer when passing to the C++ functions, which throw an error.