### PR TITLE
Denominator for "proportionalPol" sentiment computation

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -194,6 +194,16 @@ inline void update_token_scores(std::vector< double >& scores,
     scale_token_weights(tokenWeights, normalizer, nTokens);
   }
 
+  std::vector< double > denominator_proportionalPol = std::vector< double >(nL, 0);
+  if (how == "proportionalPol") {
+    for (int j = 0; j < nL; j++) {
+      for (int i = 0; i < nTokens; i++) {
+        denominator_proportionalPol[j] += abs(tokenShifters[i] * tokenScores[i][j]);
+      }
+    }
+  }
+
+
   for (int i = 0; i < nTokens; i++) {
     // std::cout << "token: " << i << "\n";
     for (int j = 0; j < nL; j++) {
@@ -210,7 +220,8 @@ inline void update_token_scores(std::vector< double >& scores,
           } else if (how == "proportional") {
             scores[j] += (tokenShifters[i] * score) / (nTokens - nPuncts);
           } else if (how == "proportionalPol") {
-            if (nPolarized[j] > 0) scores[j] += (tokenShifters[i] * score) / nPolarized[j];
+            // if (nPolarized[j] > 0) scores[j] += (tokenShifters[i] * score) / nPolarized[j];
+            if (nPolarized[j] > 0) scores[j] += (tokenShifters[i] * score) / denominator_proportionalPol[j];
           } else if (how == "proportionalSquareRoot") {
             scores[j] += (tokenShifters[i] * score) / std::sqrt(nTokens - nPuncts);
           } else {


### PR DESCRIPTION
It always tickles me that compute_sentiment can yield values outside the [-1;1] range when using the "proportionalPol" method. 

``` r
library(sentometrics)
sample_text <- setNames(nm = c("C'est un abandon", "C'est un vaste abandon"))
compute_sentiment(
  sample_text,
  lexicons = sentometrics::sento_lexicons(list(LM_sample = head(sentometrics::list_lexicons$LM_fr_tr, 5)),
                                          list_valence_shifters$fr),
  how = "proportionalPol"
)
#>                        id word_count LM_sample
#> 1:       C'est un abandon          3      -1.0
#> 2: C'est un vaste abandon          4      -1.8
```

<sup>Created on 2021-12-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

With this change, I adjusted the denominator so that it takes into account sentiment words that have been amplified-deamplified. Thus, the sentiment will always lie down within the [-1;1] interval.
The same example after the change:
``` r
library(sentometrics)
sample_text <- setNames(nm = c("C'est un abandon", "C'est un vaste abandon"))
compute_sentiment(
  sample_text,
  lexicons = sentometrics::sento_lexicons(list(LM_sample = head(sentometrics::list_lexicons$LM_fr_tr, 5)),
                                          list_valence_shifters$fr),
  how = "proportionalPol"
)
#>                        id word_count LM_sample
#> 1:       C'est un abandon          3        -1
#> 2: C'est un vaste abandon          4        -1
```

<sup>Created on 2021-12-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

